### PR TITLE
Fix machines names

### DIFF
--- a/qpid_generator/configurations.py
+++ b/qpid_generator/configurations.py
@@ -21,12 +21,12 @@ def get_conf(graph, machines, distribution):
         confs[node].update({
             'listeners': [
                 {
-                    'host': '0.0.0.0',
+                    'host': machine,
                     'port': 6000 + idx,
                     'role': 'inter-router'
                 },
                 {
-                    'host': '0.0.0.0',
+                    'host': machine,
                     'port': 5000 + idx,
                     'role': 'normal',
 

--- a/qpid_generator/graph.py
+++ b/qpid_generator/graph.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+
+import networkx as nx
+
+def generate(func_name, *args):
+    return getattr(nx, func_name)(*args)

--- a/qpid_generator/qpid_generator.py
+++ b/qpid_generator/qpid_generator.py
@@ -3,6 +3,7 @@
 
 
 import networkx
+from graph import generate
 from distribute import round_robin
 from configurations import get_conf
 
@@ -12,8 +13,6 @@ import os
 from parser import Config
 
 
-def call(func_name, *args):
-    return getattr(networkx, func_name)(*args)
 
 GEN_PATH = 'generated'
 
@@ -27,7 +26,7 @@ args = [config.routers]
 machines = config.machines
 
 # machinery
-graph = call(graph_type, *args)
+graph = generate(graph_type, *args)
 
 networkx.write_yaml(graph,'test.yaml')
 


### PR DESCRIPTION
This rebased #3 on your recent addition.

It addresses the use case where you want to split your network traffic:
Please consider looking at : https://github.com/msimonin/qpid-dispatch-xp/blob/08055ef6b25dfab43bd294f3ae654e0ce47f8bec/synthetic/ansible/roles/qpidd/templates/qdrouterd.conf.jinja2#L9